### PR TITLE
Improved image/tag parsing

### DIFF
--- a/logspoutkinesis.go
+++ b/logspoutkinesis.go
@@ -219,11 +219,22 @@ func (ka *KinesisAdapter) Stream(logstream chan *router.Message) {
 }	
 
 func splitImage(image string) (string, string) {
-    n := strings.Index(image, ":")
-    if n > -1 {
-        return image[0:n], image[n+1:]
+    tag := ""
+    parts := strings.SplitN(image, "/", 2)
+    repo := ""
+    if len(parts) == 2 {
+        repo = parts[0]
+        image = parts[1]
     }
-    return image, ""
+    parts = strings.SplitN(image, ":", 2)
+    if len(parts) == 2 {
+        image = parts[0]
+        tag = parts[1]
+    }
+    if repo != "" {
+        image = fmt.Sprintf("%s/%s", repo, image)
+    }
+    return image, tag
 }
 
 func createLogstashMessage(m *router.Message, docker_host string, use_v0 bool) interface{} {


### PR DESCRIPTION
The image name might have two ':' characters because there can be a colon character between the hostname and port in the registry domain.

```
package main

import "fmt"
import "strings"

func main() {
	image, tag := parseImageName("my.registry.com:5000/spaaza/logspout-kinesis:v_201509211407")
	image2, tag2 := parseImageName("animage")
	image3, tag3 := parseImageName("animage:v_1")
	image4, tag4 := parseImageName("blah/animage")
	image5, tag5 := parseImageName("blah/animage:v_1")
	fmt.Printf("image: %s, tag: %s\n", image, tag)
	fmt.Printf("image: %s, tag: %s\n", image2, tag2)
	fmt.Printf("image: %s, tag: %s\n", image3, tag3)
	fmt.Printf("image: %s, tag: %s\n", image4, tag4)
	fmt.Printf("image: %s, tag: %s\n", image5, tag5)
}

func parseImageName(image string) (string, string) {
  tag := ""
  parts := strings.SplitN(image, "/", 2)
  repo := ""
  if len(parts) == 2 {
    repo = parts[0]
    image = parts[1]
  }
  parts = strings.SplitN(image, ":", 2)
  if len(parts) == 2 {
    image = parts[0]
    tag = parts[1]
  }
  if repo != "" {
    image = fmt.Sprintf("%s/%s", repo, image)
  }
  return image, tag
}

OUTPUT:

image: my.registry.com:5000/spaaza/logspout-kinesis, tag: v_201509211407
image: animage, tag: 
image: animage, tag: v_1
image: blah/animage, tag: 
image: blah/animage, tag: v_1
```
